### PR TITLE
Music Library: Fix bugs with Filters component

### DIFF
--- a/next-js/app/music/components/Filters.tsx
+++ b/next-js/app/music/components/Filters.tsx
@@ -141,9 +141,16 @@ export function Filters({
     facets.includes(facet.id as FilterFacetId)
   );
 
-  const formatOptionLabel = ({ label, count, type }: SelectOption) => (
+  const formatOptionLabel = (
+    { label, count, type }: SelectOption,
+    { context }: { context: string }
+  ) => (
     <div className="flex justify-between gap-2">
-      <span>{label}</span>
+      <span>
+        {context === "value" && facets.length > 1
+          ? `${activeFacets.find((f) => f.id === type)?.label}: ${label}`
+          : label}
+      </span>
       {count !== undefined && <span>({count})</span>}
     </div>
   );

--- a/next-js/app/music/components/Filters.tsx
+++ b/next-js/app/music/components/Filters.tsx
@@ -40,6 +40,7 @@ export interface FiltersProps {
   updateUrl?: boolean;
   initialFilters?: Record<string, string>;
   onFiltersChange?: (filters: Record<string, string>) => void;
+  customCounts?: Record<string, Record<string, number>>;
 }
 
 const selectStyles: StylesConfig<SelectOption, boolean> = {
@@ -126,12 +127,14 @@ export function Filters({
   updateUrl = true,
   initialFilters = {},
   onFiltersChange,
+  customCounts,
 }: FiltersProps) {
   const { availableFacets, handleChange } = useFilters({
     facets,
     updateUrl,
     initialFilters,
     onFiltersChange,
+    customCounts,
   });
 
   const activeFacets = availableFacets.filter((facet) =>

--- a/next-js/app/music/components/IndexPage.tsx
+++ b/next-js/app/music/components/IndexPage.tsx
@@ -25,6 +25,7 @@ interface IndexPageProps {
   initialFilters?: Record<string, string>;
   onFiltersChange?: (filters: Record<string, string>) => void;
   updateUrl?: boolean;
+  customCounts?: Record<string, Record<string, number>>;
 }
 
 export function IndexPage({
@@ -36,6 +37,7 @@ export function IndexPage({
   initialFilters = {},
   onFiltersChange,
   updateUrl = true,
+  customCounts,
 }: IndexPageProps) {
   const { sortedItems, currentSort, handleSort, sortOptions } = useSorting({
     items,
@@ -61,6 +63,7 @@ export function IndexPage({
           initialFilters={initialFilters}
           onFiltersChange={onFiltersChange}
           updateUrl={updateUrl}
+          customCounts={customCounts}
         />
       )}
 

--- a/next-js/app/music/works/page.tsx
+++ b/next-js/app/music/works/page.tsx
@@ -4,7 +4,7 @@ import { IndexPage } from "@music/components/IndexPage";
 import { formatWorkTitle, formatComposerName } from "../lib/helpers";
 import { getWorks } from "@music/data/queries/works";
 import { getSeasonBySlug } from "@music/data/queries/seasons";
-import { getComposerBySlug } from "@music/data/queries/composers";
+import { getComposerBySlug, getComposers } from "@music/data/queries/composers";
 import { getConcertsByWork } from "@music/data/queries/concerts";
 import { BucketList } from "@music/components/BucketList";
 
@@ -69,6 +69,18 @@ export default function WorksPage({
     };
   });
 
+  // Pre-calculate work counts for each composer
+  const allWorks = getWorks();
+  const customCounts = {
+    composer: Object.fromEntries(
+      getComposers().map((composer) => [
+        composer.title,
+        allWorks.filter((work) => work.frontmatter.composer === composer.title)
+          .length,
+      ])
+    ),
+  };
+
   return (
     <div>
       <IndexPage
@@ -78,6 +90,7 @@ export default function WorksPage({
         showFilters={true}
         facets={["composer"]}
         initialFilters={searchParams as Record<string, string>}
+        customCounts={customCounts}
       />
     </div>
   );


### PR DESCRIPTION
I noted this bug in the first wave of testing:

> 🐛 Composers dropdown is showing count of concerts instead of count of works

### Fix counts

On "Works" page, the counts now represent the number of works the composer has, instead of the number of concerts in which the composer has had a work performed:

<img width="831" alt="image" src="https://github.com/user-attachments/assets/ac5625c6-d1cd-4cc4-856d-9d4ba06b1534" />
 

### Show facet on selected option labels for multi select mode

On the Concerts page Filters, we now show a label like `Season:` or `Group:` in front of the selected option labels:

<img width="812" alt="image" src="https://github.com/user-attachments/assets/25b4180c-9f22-4074-9b5b-a35303b298e4" />
