### PR TITLE
Music Library: Fixes for "Upcoming" behavior

### DIFF
--- a/next-js/app/awds/page.mdx
+++ b/next-js/app/awds/page.mdx
@@ -38,6 +38,7 @@ import { SectionHeading } from "@music/components/SectionHeading";
 import { CalendarUrlCopy } from "@music/components/CalendarUrlCopy";
 import { AttendActions } from "@music/components/AttendActions";
 import VenueMap from "@music/components/VenueMap";
+import { HappeningNow } from "@music/components/HappeningNow";
 
 export const metadata = { title: "AWDS" };
 
@@ -507,6 +508,16 @@ This badge is used to indicate when I didn't play in a particular concert, or it
 
 <ComponentWrapper>
   <DidNotPlay />
+</ComponentWrapper>
+
+---
+
+### HappeningNow
+
+This badge is used to indicate concerts that are currently in progress (within 2 hours of start time).
+
+<ComponentWrapper>
+  <HappeningNow />
 </ComponentWrapper>
 
 ---

--- a/next-js/app/music/components/AttendActions.tsx
+++ b/next-js/app/music/components/AttendActions.tsx
@@ -7,7 +7,7 @@ interface AttendActionsProps {
 }
 
 export const AttendActions = ({ concert }: AttendActionsProps) => {
-  if (!isUpcoming(concert.frontmatter.date)) {
+  if (!isUpcoming(concert)) {
     return null;
   }
 

--- a/next-js/app/music/components/ConcertBadges.tsx
+++ b/next-js/app/music/components/ConcertBadges.tsx
@@ -1,6 +1,7 @@
 import { DidNotPlay } from "./DidNotPlay";
 import { Upcoming } from "./Upcoming";
-import { isUpcoming } from "@music/lib/helpers";
+import { HappeningNow } from "./HappeningNow";
+import { isUpcoming, isHappeningNow } from "@music/lib/helpers";
 import { Concert } from "@music/lib/types";
 
 interface ConcertBadgesProps {
@@ -9,9 +10,10 @@ interface ConcertBadgesProps {
 
 export const ConcertBadges = ({ concert }: ConcertBadgesProps) => {
   return (
-    <>
+    <span className="inline-flex gap-2">
       {concert.frontmatter.didNotPlay && <DidNotPlay />}
-      {isUpcoming(concert.frontmatter.date) && <Upcoming />}
-    </>
+      {isHappeningNow(concert) && <HappeningNow />}
+      {isUpcoming(concert) && !isHappeningNow(concert) && <Upcoming />}
+    </span>
   );
 };

--- a/next-js/app/music/components/ConcertListItem.tsx
+++ b/next-js/app/music/components/ConcertListItem.tsx
@@ -113,7 +113,7 @@ export async function ConcertListItem({
         </dl>
       </div>
 
-      {showAttendActions && isUpcoming(concert.frontmatter.date) && (
+      {showAttendActions && isUpcoming(concert) && (
         <AttendActions concert={concert} />
       )}
     </article>

--- a/next-js/app/music/components/HappeningNow.tsx
+++ b/next-js/app/music/components/HappeningNow.tsx
@@ -1,0 +1,7 @@
+export const HappeningNow = () => {
+  return (
+    <span className="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
+      Happening now!
+    </span>
+  );
+};

--- a/next-js/app/music/concerts/[slug]/page.tsx
+++ b/next-js/app/music/concerts/[slug]/page.tsx
@@ -77,7 +77,7 @@ export default async function ConcertPage(props: PageProps) {
     <article className="flex flex-col gap-6">
       <PageTitle>{displayTitle}</PageTitle>
 
-      {isUpcoming(concert.frontmatter.date) && (
+      {isUpcoming(concert) && (
         <div className="mb-6">
           <SectionHeading>Attend</SectionHeading>
           <AttendActions concert={concert} />

--- a/next-js/app/music/concerts/page.tsx
+++ b/next-js/app/music/concerts/page.tsx
@@ -13,17 +13,16 @@ import { IndexPage } from "../components/IndexPage";
 import { routes } from "../lib/routes";
 import { Upcoming } from "../components/Upcoming";
 import { ConcertListItem } from "../components/ConcertListItem";
+import { ConcertBadges } from "../components/ConcertBadges";
 
 export const metadata: Metadata = {
   title: "Concerts",
   description: "Concerts I've performed in",
 };
 
-export default async function ConcertsPage(
-  props: {
-    searchParams: Promise<{ [key: string]: string | undefined }>;
-  }
-) {
+export default async function ConcertsPage(props: {
+  searchParams: Promise<{ [key: string]: string | undefined }>;
+}) {
   const searchParams = await props.searchParams;
   let concerts = [...getConcerts()];
 
@@ -86,7 +85,7 @@ export default async function ConcertsPage(
         alphabetical: false,
         date: concert.frontmatter.date,
       },
-      badges: [isUpcoming(concert.frontmatter.date) ? <Upcoming /> : null],
+      badges: [<ConcertBadges key={concert.slug} concert={concert} />],
     };
   });
 

--- a/next-js/app/music/data/queries/concerts.ts
+++ b/next-js/app/music/data/queries/concerts.ts
@@ -1,6 +1,10 @@
 import database from "../database";
 import { Concert } from "@music/lib/types";
-import { getDateFromFrontmatter, isUpcoming } from "@music/lib/helpers";
+import {
+  getDateFromFrontmatter,
+  isUpcoming,
+  isHappeningNow,
+} from "@music/lib/helpers";
 
 export function getConcerts() {
   return database.concert;
@@ -52,7 +56,7 @@ export function getUpcomingConcerts() {
   return database.concert
     .filter((concert) => {
       const date = getDateFromFrontmatter(concert);
-      return date ? isUpcoming(date.toISOString()) : false;
+      return date ? isUpcoming(concert) || isHappeningNow(concert) : false;
     })
     .sort((a, b) => {
       const dateA = getDateFromFrontmatter(a);

--- a/next-js/app/music/lib/calendar.ts
+++ b/next-js/app/music/lib/calendar.ts
@@ -1,25 +1,16 @@
-import tzlookup from "tz-lookup";
 import { DateTime } from "luxon";
 import { createEvents, DateArray, EventAttributes } from "ics";
-import { Concert, Venue } from "@music/lib/types";
-import { formatConcertTitle, getSiteUrl } from "@music/lib/helpers";
+import { Concert } from "@music/lib/types";
+import {
+  formatConcertTitle,
+  getSiteUrl,
+  getVenueTimeZone,
+} from "@music/lib/helpers";
 import { getVenueByTitle } from "@music/data/queries/venues";
 import { getGroupByTitle } from "@music/data/queries/groups";
 import { awdsColors } from "@andrewwestling/tailwind-config";
 
 const PRIMARY_COLOR = awdsColors.primary.DEFAULT;
-const DEFAULT_TIMEZONE = "America/New_York";
-
-// Get timezone from venue coordinates if available
-function getTimeZone(venue?: Venue) {
-  if (venue?.frontmatter.coordinates) {
-    const [lat, lon] = venue.frontmatter.coordinates
-      .split(",")
-      .map((c) => parseFloat(c.trim()));
-    return tzlookup(lat, lon);
-  }
-  return DEFAULT_TIMEZONE;
-}
 
 // Convert a concert into an ICS event object
 export function concertToEvent(concert: Concert): EventAttributes {
@@ -32,9 +23,7 @@ export function concertToEvent(concert: Concert): EventAttributes {
   // Parse the date as local time in the venue's timezone
   const localDate = DateTime.fromISO(
     concert.frontmatter.date.replace("Z", ""),
-    {
-      zone: getTimeZone(venue),
-    }
+    { zone: getVenueTimeZone(venue) }
   );
 
   // Convert to UTC for the calendar

--- a/next-js/app/music/upcoming.ics/route.ts
+++ b/next-js/app/music/upcoming.ics/route.ts
@@ -1,8 +1,12 @@
-import { getUpcomingConcerts } from "@music/data/queries/concerts";
+import { getConcertsBySeason } from "@music/data/queries/concerts";
 import { concertToEvent, generateCalendarResponse } from "@music/lib/calendar";
+import { getCurrentSeasonSlug } from "../lib/helpers";
 
 export async function GET() {
-  const concerts = getUpcomingConcerts();
+  const currentSeasonSlug = getCurrentSeasonSlug();
+  const concerts = currentSeasonSlug
+    ? getConcertsBySeason(currentSeasonSlug)
+    : [];
   const events = concerts.map(concertToEvent);
 
   return generateCalendarResponse({

--- a/next-js/app/music/upcoming/page.tsx
+++ b/next-js/app/music/upcoming/page.tsx
@@ -6,6 +6,11 @@ import { SectionHeading } from "../components/SectionHeading";
 import { CalendarUrlCopy } from "../components/CalendarUrlCopy";
 import { PageTitle } from "../components/PageTitle";
 
+/**
+ * Revalidate every hour so the "up next" concert will be correct after the concert happens
+ */
+export const revalidate = 3600;
+
 export const metadata: Metadata = {
   title: "Upcoming Concerts",
   description: "Upcoming concerts I'm performing in",


### PR DESCRIPTION
Today was the first test of what would happen when an upcoming concert is no longer "upcoming", so I got to learn what bugs happen with that area of the site 😆 

## Fixes
- Force Upcoming page to render dynamically
  - By default, the page is only generated at build time
  - Needed to add the `export const dynamic = 'force-dynamic'` thing, to force it to regenerate on render so the information will be up to date
- Fix `upcoming.ics` to keep concerts on the calendar even after they happen 
  - I was looking for the event in my calendar app during the concert and saw the concert had disappeared
  - <img width="361" alt="image" src="https://github.com/user-attachments/assets/28c53e49-ec8a-44bb-8f8d-033be30dd64e" />
  - I just reworked the `upcoming.ics` feed to basically be "this season's concerts" instead of "only upcoming concerts" so it will still keep concerts from the recent past* on there (one season rolling feels like the right balance; will show concerts back to the beginning of this season, and up to the end of this season)

- Make "Upcoming" calculations respect the venue's time zone 
  - (Choosing to store the venue's coordinates unlocked a lot of fun stuff with this; that was a good call) 
  - Make the Upcoming stuff respond to the time zone of the venue (
  - Relocate` getTimeZone` stuff from calendar.ts to helpers, since it's no longer just the calendar using it
  - Rework `isUpcoming` to take the whole concert object instead of just the date
  - Make upcoming page force dynamic so it will always be up to date
- Add easter egg: when a concert is currently happening (within 2 hours of the start time in the venue time zone) the badge will change to "Happening now!"
  - <img width="942" alt="Screenshot 2025-02-09 at 9 34 37 PM  Happening now" src="https://github.com/user-attachments/assets/ffec5e4e-9b3a-4d3a-8289-ede66a13575a" />
