### PR TITLE
Music Library: Rework "Concert Info" and List Item badges

### DIFF
--- a/next-js/app/awds/page.mdx
+++ b/next-js/app/awds/page.mdx
@@ -41,7 +41,9 @@ import { CalendarUrlCopy } from "@music/components/CalendarUrlCopy";
 import { AttendActions } from "@music/components/AttendActions";
 import VenueMap from "@music/components/VenueMap";
 import { HappeningNow } from "@music/components/HappeningNow";
+import { ConcertBadges } from "@music/components/ConcertBadges";
 import { BackForwardNavigation } from "@music/components/BackForwardNavigation";
+import { ConcertInfo } from "@music/components/ConcertInfo";
 
 export const metadata = { title: "AWDS" };
 
@@ -332,11 +334,9 @@ These components are specific to the music section of the website.
 
 This is used when listing concerts on a page.
 
-It extends the ListItem component, adding badges and a few other things that are specific to concerts.
-
-- Shows the concert title, the group name, and the date
+It shows the concert title, the group name, and the date in a compact format.
 - Falls back to the group name if a concert title isn't available
-- Has an optional `expanded` prop that shows the group name and the date
+- Shows badges for upcoming concerts and other statuses
 
 <ComponentWrapper>
   <div className="grid gap-6">
@@ -351,14 +351,6 @@ It extends the ListItem component, adding badges and a few other things that are
       />
     </Variant>
 
-    <Variant label="Without Title, Expanded">
-      <ConcertListItem
-        concert={sampleConcertWithoutTitle}
-        group={sampleGroup}
-        expanded
-      />
-    </Variant>
-
     <Variant label="With Upcoming Date">
       <ConcertListItem
         concert={sampleConcertWithUpcomingDate}
@@ -368,11 +360,43 @@ It extends the ListItem component, adding badges and a few other things that are
   </div>
 </ComponentWrapper>
 
+### ConcertInfo
+
+This is used to show detailed information about a concert.
+
+It shows:
+- The concert title and date
+- The venue and its location
+- The performing group
+- The conductor(s)
+
+Optional props:
+- `showAttendActions` - Show "AttendActions" buttons for upcoming concerts
+- `titleAsLink` - The defaults to being a hyperlink; we can set this to false for Concert Detail pages since we don't need a link to a page we're already on
+
+<ComponentWrapper>
+  <div className="grid gap-6">
+    <Variant label="Basic">
+      <ConcertInfo concert={sampleConcertWithTitle} />
+    </Variant>
+
+    <Variant label="With Attend Actions">
+      <ConcertInfo concert={sampleConcertWithUpcomingDate} showAttendActions />
+    </Variant>
+
+    <Variant label="With Unlinked Title (for Concert Detail pages)">
+      <ConcertInfo concert={sampleConcertWithTitle} titleAsLink={false} />
+    </Variant>
+  </div>
+</ComponentWrapper>
+
 ---
 
 ### ListItem
 
-This is a generic list item component used throughout the music section to display various types of data in a consistent format. It shows a title as a link with optional statistics.
+This is a generic list item component used throughout the music section to display various types of data in a consistent format. It shows a title as a link with optional statistics and badges. The component supports two types of badges:
+- `titleBadges` - badges that appear next to the title (example: Bucket List badge)
+- `statsBadges` - badges that appear next to the stats (example: Upcoming/Happening Now badges)
 
 <ComponentWrapper>
   <div className="grid gap-4">
@@ -419,21 +443,39 @@ This is a generic list item component used throughout the music section to displ
       />
     </Variant>
 
-    <Variant label="Work Example, Bucket List">
+    <Variant label="Work Example with titleBadges (Bucket List badge)">
       <ListItem
         title="Symphony No. 1 in E Minor"
         href="/music/works/sibelius-symphony-no-1-in-e-minor"
         stats={["by Jean Sibelius"]}
-        badges={[<BucketList />]}
+        titleBadges={[<BucketList />]}
       />
     </Variant>
 
-    <Variant label="Work Example, Bucket List, Played">
+    <Variant label="Work Example with titleBadges (Bucket List badge, played)">
       <ListItem
         title="Symphony No. 1 in E Minor"
         href="/music/works/sibelius-symphony-no-1-in-e-minor"
         stats={["by Jean Sibelius"]}
-        badges={[<BucketList played />]}
+        titleBadges={[<BucketList played />]}
+      />
+    </Variant>
+
+    <Variant label="Concert Example with statsBadges (Upcoming badge)">
+      <ListItem
+        title="Example Concert"
+        href="/music/concerts/example"
+        stats={["January 1, 2024"]}
+        statsBadges={[<ConcertBadges concert={sampleConcertWithUpcomingDate} />]}
+      />
+    </Variant>
+
+    <Variant label="Concert Example with statsBadges (Happening Now badge)">
+      <ListItem
+        title="Example Concert"
+        href="/music/concerts/example"
+        stats={["January 1, 2024"]}
+        statsBadges={[<HappeningNow />]}
       />
     </Variant>
   </div>

--- a/next-js/app/components/EmptyState.tsx
+++ b/next-js/app/components/EmptyState.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from "react";
+
+interface EmptyStateProps {
+  title: string;
+  description?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  title,
+  description,
+  className = "",
+}: EmptyStateProps) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center py-12 px-4 text-center ${className} bg-surface dark:bg-surface-dark rounded-lg`}
+    >
+      <p className="text-preset-3-bold">{title}</p>
+      {description && <p className="mt-2 text-preset-2">{description}</p>}
+    </div>
+  );
+}

--- a/next-js/app/music/components/ConcertInfo.tsx
+++ b/next-js/app/music/components/ConcertInfo.tsx
@@ -1,0 +1,107 @@
+import Link from "next/link";
+import { ConcertBadges } from "./ConcertBadges";
+import {
+  formatConcertTitle,
+  formatDate,
+  findConductorSlug,
+  isUpcoming,
+} from "@music/lib/helpers";
+import { routes } from "@music/lib/routes";
+import { Concert } from "@music/lib/types";
+import { getLocationFromCoordinates } from "@music/lib/location";
+import { getGroupByTitle } from "@music/data/queries/groups";
+import { getVenueByTitle } from "@music/data/queries/venues";
+import { AttendActions } from "./AttendActions";
+
+interface ConcertInfoProps {
+  concert: Concert;
+  showAttendActions?: boolean;
+  titleAsLink?: boolean;
+}
+
+export async function ConcertInfo({
+  concert,
+  showAttendActions = false,
+  titleAsLink = true,
+}: ConcertInfoProps) {
+  const group = getGroupByTitle(concert.frontmatter.group);
+  const venue = concert.frontmatter.venue
+    ? getVenueByTitle(concert.frontmatter.venue)
+    : undefined;
+  const displayTitle = formatConcertTitle(concert.title, group);
+  const formattedDate = formatDate(concert.frontmatter.date);
+
+  // Get conductor(s)
+  const conductors = Array.isArray(concert.frontmatter.conductor)
+    ? concert.frontmatter.conductor
+    : concert.frontmatter.conductor
+    ? [concert.frontmatter.conductor]
+    : [];
+
+  return (
+    <article className="space-y-6">
+      <div className="space-y-4">
+        <div className="text-preset-3 flex items-center">
+          <span>
+            {formattedDate}
+            <span className="ml-2">
+              <ConcertBadges key={concert.slug} concert={concert} />
+            </span>
+          </span>
+        </div>
+        <h3 className="text-preset-7">
+          {titleAsLink ? (
+            <Link href={routes.concerts.show(concert.slug)}>
+              {displayTitle}
+            </Link>
+          ) : (
+            displayTitle
+          )}
+        </h3>
+      </div>
+
+      <div className="space-y-4">
+        {venue && (
+          <>
+            <Link href={routes.venues.show(venue.slug)}>{venue.title}</Link>
+            {venue.frontmatter.coordinates && (
+              <span className="text-preset-2 ml-2">
+                (
+                {await getLocationFromCoordinates(
+                  venue.frontmatter.coordinates
+                )}
+                )
+              </span>
+            )}
+          </>
+        )}
+        {group && (
+          <div>
+            <Link href={routes.groups.show(group.slug)}>{group.title}</Link>
+          </div>
+        )}
+        {conductors.length > 0 && (
+          <span>
+            {conductors.map((conductorName, i) => (
+              <span key={conductorName}>
+                {i > 0 && ", "}
+                <Link
+                  href={routes.conductors.show(
+                    findConductorSlug(conductorName) || ""
+                  )}
+                >
+                  {conductorName}
+                </Link>
+              </span>
+            ))}
+            <span>, conductor{conductors.length > 1 ? "s" : ""}</span>
+          </span>
+        )}
+      </div>
+
+      {showAttendActions && isUpcoming(concert) && (
+        <AttendActions concert={concert} />
+      )}
+    </article>
+  );
+}

--- a/next-js/app/music/components/ConcertListItem.tsx
+++ b/next-js/app/music/components/ConcertListItem.tsx
@@ -1,113 +1,26 @@
-import Link from "next/link";
 import { ConcertBadges } from "./ConcertBadges";
-import {
-  formatConcertTitle,
-  formatDate,
-  findConductorSlug,
-  isUpcoming,
-} from "@music/lib/helpers";
+import { formatConcertTitle, formatDate } from "@music/lib/helpers";
 import { routes } from "@music/lib/routes";
 import { Concert } from "@music/lib/types";
-import { getLocationFromCoordinates } from "@music/lib/location";
 import { getGroupByTitle } from "@music/data/queries/groups";
-import { getVenueByTitle } from "@music/data/queries/venues";
 import { ListItem } from "./ListItem";
-import { AttendActions } from "./AttendActions";
 
 interface ConcertListItemProps {
   concert: Concert;
-  expanded?: boolean;
   showAttendActions?: boolean;
 }
 
-export async function ConcertListItem({
-  concert,
-  expanded = false,
-  showAttendActions = false,
-}: ConcertListItemProps) {
+export async function ConcertListItem({ concert }: ConcertListItemProps) {
   const group = getGroupByTitle(concert.frontmatter.group);
-  const venue = concert.frontmatter.venue
-    ? getVenueByTitle(concert.frontmatter.venue)
-    : undefined;
   const displayTitle = formatConcertTitle(concert.title, group);
   const formattedDate = formatDate(concert.frontmatter.date);
 
-  // Get conductor(s)
-  const conductors = Array.isArray(concert.frontmatter.conductor)
-    ? concert.frontmatter.conductor
-    : concert.frontmatter.conductor
-    ? [concert.frontmatter.conductor]
-    : [];
-
-  if (!expanded) {
-    return (
-      <ListItem
-        title={displayTitle}
-        href={routes.concerts.show(concert.slug)}
-        stats={[formattedDate]}
-        badges={[<ConcertBadges key={concert.slug} concert={concert} />]}
-      />
-    );
-  }
-
   return (
-    <article className="space-y-6">
-      <div className="space-y-4">
-        <div className="text-preset-3 flex items-center">
-          <span>
-            {formattedDate}
-            <span className="ml-2">
-              <ConcertBadges key={concert.slug} concert={concert} />
-            </span>
-          </span>
-        </div>
-        <h3 className="text-preset-7">
-          <Link href={routes.concerts.show(concert.slug)}>{displayTitle}</Link>
-        </h3>
-      </div>
-
-      <div className="space-y-4">
-        {venue && (
-          <>
-            <Link href={routes.venues.show(venue.slug)}>{venue.title}</Link>
-            {venue.frontmatter.coordinates && (
-              <span className="text-preset-2 ml-2">
-                (
-                {await getLocationFromCoordinates(
-                  venue.frontmatter.coordinates
-                )}
-                )
-              </span>
-            )}
-          </>
-        )}
-        {group && (
-          <div>
-            <Link href={routes.groups.show(group.slug)}>{group.title}</Link>
-          </div>
-        )}
-        {conductors.length > 0 && (
-          <span>
-            {conductors.map((conductorName, i) => (
-              <span key={conductorName}>
-                {i > 0 && ", "}
-                <Link
-                  href={routes.conductors.show(
-                    findConductorSlug(conductorName) || ""
-                  )}
-                >
-                  {conductorName}
-                </Link>
-              </span>
-            ))}
-            <span>, conductor{conductors.length > 1 ? "s" : ""}</span>
-          </span>
-        )}
-      </div>
-
-      {showAttendActions && isUpcoming(concert) && (
-        <AttendActions concert={concert} />
-      )}
-    </article>
+    <ListItem
+      title={displayTitle}
+      href={routes.concerts.show(concert.slug)}
+      stats={[formattedDate]}
+      statsBadges={[<ConcertBadges key={concert.slug} concert={concert} />]}
+    />
   );
 }

--- a/next-js/app/music/components/IndexPage.tsx
+++ b/next-js/app/music/components/IndexPage.tsx
@@ -17,7 +17,8 @@ interface IndexPageProps {
       [key in SortType]?: any;
     };
     className?: string;
-    badges?: React.ReactNode[];
+    titleBadges?: React.ReactNode[];
+    statsBadges?: React.ReactNode[];
   }>;
   defaultSort?: SortType;
   showFilters?: boolean;
@@ -74,7 +75,8 @@ export function IndexPage({
             title={item.title}
             href={item.href}
             stats={item.stats}
-            badges={item.badges}
+            titleBadges={item.titleBadges}
+            statsBadges={item.statsBadges}
             className={item.className}
           />
         ))}

--- a/next-js/app/music/components/ListItem.tsx
+++ b/next-js/app/music/components/ListItem.tsx
@@ -4,7 +4,8 @@ interface ListItemProps {
   title: string;
   href: string;
   stats: (string | undefined | null)[];
-  badges?: React.ReactNode[];
+  statsBadges?: React.ReactNode[];
+  titleBadges?: React.ReactNode[];
   className?: string;
 }
 
@@ -12,21 +13,28 @@ export function ListItem({
   title,
   href,
   stats,
-  badges = [],
+  statsBadges = [],
+  titleBadges = [],
   className = "",
 }: ListItemProps) {
+  const statsBadgeSlot = statsBadges.map((stat, index) => (
+    <span key={index}>{stat}</span>
+  ));
+  const titleBadgeSlot = titleBadges.map((badge, index) => (
+    <span key={index}>{badge}</span>
+  ));
   return (
     <div className={className}>
-      <Link href={href} className="text-preset-3-bold">
-        {title}
-      </Link>
-      <p className="text-preset-2 text-muted flex flex-row gap-2">
+      <div className="flex items-center">
+        <Link href={href} className="text-preset-3-bold">
+          {title}
+        </Link>
+        {titleBadgeSlot && <span className="ml-2">{titleBadgeSlot}</span>}
+      </div>
+
+      <p className="text-preset-2 text-muted">
         <span>{stats.join(" • ")}</span>
-        <span>
-          {badges.map((badge, index) => (
-            <span key={index}>{badge}</span>
-          ))}
-        </span>
+        <span className="ml-2">{statsBadgeSlot}</span>
       </p>
     </div>
   );

--- a/next-js/app/music/components/ListItem.tsx
+++ b/next-js/app/music/components/ListItem.tsx
@@ -31,11 +31,12 @@ export function ListItem({
         </Link>
         {titleBadgeSlot && <span className="ml-2">{titleBadgeSlot}</span>}
       </div>
-
-      <p className="text-preset-2 text-muted">
-        <span>{stats.join(" • ")}</span>
-        <span className="ml-2">{statsBadgeSlot}</span>
-      </p>
+      {stats.length > 0 && (
+        <p className="text-preset-2 text-muted">
+          <span>{stats.join(" • ")}</span>
+          <span className="ml-2">{statsBadgeSlot}</span>
+        </p>
+      )}
     </div>
   );
 }

--- a/next-js/app/music/composers/[slug]/page.tsx
+++ b/next-js/app/music/composers/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { formatWorkTitle, formatComposerName } from "../../lib/helpers";
 import { ListItem } from "../../components/ListItem";
 import { PageTitle } from "@music/components/PageTitle";
 import { SectionHeading } from "@music/components/SectionHeading";
+import { EmptyState } from "@/app/components/EmptyState";
 import { getComposerBySlug } from "@music/data/queries/composers";
 import { getWorksByComposer } from "@music/data/queries/works";
 import { BucketList } from "../../components/BucketList";
@@ -37,9 +38,9 @@ export default async function ComposerPage(props: PageProps) {
       <div>
         <PageTitle>{formatComposerName(composer.title)}</PageTitle>
       </div>
-      {works.length > 0 && (
-        <div className="mb-8">
-          <SectionHeading>Works</SectionHeading>
+      <div className="mb-8">
+        <SectionHeading>Works</SectionHeading>
+        {works.length > 0 ? (
           <div className="grid gap-4">
             {works.map((work) => (
               <ListItem
@@ -55,8 +56,15 @@ export default async function ComposerPage(props: PageProps) {
               />
             ))}
           </div>
-        </div>
-      )}
+        ) : (
+          <EmptyState
+            title="No works yet"
+            description={`I haven't performed any works by ${formatComposerName(
+              composer.title
+            )} yet.`}
+          />
+        )}
+      </div>
     </article>
   );
 }

--- a/next-js/app/music/composers/[slug]/page.tsx
+++ b/next-js/app/music/composers/[slug]/page.tsx
@@ -48,7 +48,7 @@ export default async function ComposerPage(props: PageProps) {
                 title={formatWorkTitle(work)}
                 href={routes.works.show(work.slug)}
                 stats={[]}
-                badges={[
+                titleBadges={[
                   work.bucketList ? (
                     <BucketList played={work.concertCount > 0} />
                   ) : null,

--- a/next-js/app/music/concerts/[slug]/page.tsx
+++ b/next-js/app/music/concerts/[slug]/page.tsx
@@ -7,7 +7,6 @@ import {
   formatConcertTitle,
   formatWorkTitle,
   formatComposerName,
-  isUpcoming,
   getNextConcert,
   getPreviousConcert,
 } from "@music/lib/helpers";
@@ -20,13 +19,10 @@ import { getConcertBySlug } from "@music/data/queries/concerts";
 import { getGroupByTitle } from "@music/data/queries/groups";
 import { getWorkByTitle } from "@music/data/queries/works";
 import { getVenueByTitle } from "@music/data/queries/venues";
-import { ConcertBadges } from "@music/components/ConcertBadges";
 import { SectionHeading } from "@music/components/SectionHeading";
-import { PageTitle } from "@music/components/PageTitle";
 import { BucketList } from "@music/components/BucketList";
-import { AttendActions } from "@music/components/AttendActions";
 import { BackForwardNavigation } from "@music/components/BackForwardNavigation";
-import { ConcertListItem } from "@music/components/ConcertListItem";
+import { ConcertInfo } from "@music/components/ConcertInfo";
 
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
@@ -84,7 +80,7 @@ export default async function ConcertPage(props: PageProps) {
   return (
     <article className="space-y-12">
       <div className="flex flex-row items-start justify-between gap-4">
-        <ConcertListItem concert={concert} expanded showAttendActions />
+        <ConcertInfo concert={concert} showAttendActions titleAsLink={false} />
         <div className="hidden sm:block">
           <BackForwardNavigation
             prev={prevConcert}
@@ -119,7 +115,7 @@ export default async function ConcertPage(props: PageProps) {
                       work.frontmatter.composer &&
                         `by ${formatComposerName(work.frontmatter.composer)}`,
                     ]}
-                    badges={[
+                    titleBadges={[
                       work.bucketList ? (
                         <BucketList played={work.concertCount > 0} />
                       ) : null,

--- a/next-js/app/music/concerts/page.tsx
+++ b/next-js/app/music/concerts/page.tsx
@@ -3,7 +3,6 @@ import {
   formatConcertTitle,
   formatDate,
   getDateForSorting,
-  isUpcoming,
 } from "@music/lib/helpers";
 import { getConcerts } from "@music/data/queries/concerts";
 import { getGroupBySlug, getGroupByTitle } from "@music/data/queries/groups";
@@ -11,8 +10,6 @@ import { getSeasonBySlug, getCurrentSeason } from "@music/data/queries/seasons";
 import { getConductorBySlug } from "@music/data/queries/conductors";
 import { IndexPage } from "../components/IndexPage";
 import { routes } from "../lib/routes";
-import { Upcoming } from "../components/Upcoming";
-import { ConcertListItem } from "../components/ConcertListItem";
 import { ConcertBadges } from "../components/ConcertBadges";
 
 export const metadata: Metadata = {
@@ -85,7 +82,7 @@ export default async function ConcertsPage(props: {
         alphabetical: false,
         date: concert.frontmatter.date,
       },
-      badges: [<ConcertBadges key={concert.slug} concert={concert} />],
+      statsBadges: [<ConcertBadges key={concert.slug} concert={concert} />],
     };
   });
 

--- a/next-js/app/music/data/vault-data.json
+++ b/next-js/app/music/data/vault-data.json
@@ -281,7 +281,7 @@
       "content": "",
       "frontmatter": {
         "composer": "Beethoven, Ludwig van",
-        "catalogue": "Op. 72b"
+        "catalogue": "Op. 72c"
       },
       "concertCount": 3,
       "bucketList": false
@@ -7339,7 +7339,7 @@
               "content": "",
               "frontmatter": {
                 "composer": "Beethoven, Ludwig van",
-                "catalogue": "Op. 72b"
+                "catalogue": "Op. 72c"
               },
               "concertCount": 3,
               "bucketList": false
@@ -7480,7 +7480,7 @@
               "content": "",
               "frontmatter": {
                 "composer": "Beethoven, Ludwig van",
-                "catalogue": "Op. 72b"
+                "catalogue": "Op. 72c"
               },
               "concertCount": 3,
               "bucketList": false
@@ -7585,7 +7585,7 @@
               "content": "",
               "frontmatter": {
                 "composer": "Beethoven, Ludwig van",
-                "catalogue": "Op. 72b"
+                "catalogue": "Op. 72c"
               },
               "concertCount": 3,
               "bucketList": false

--- a/next-js/app/music/data/vault-data.json
+++ b/next-js/app/music/data/vault-data.json
@@ -812,7 +812,7 @@
       "type": "work",
       "path": "Works/Copland - Appalachian Spring.md",
       "title": "Copland - Appalachian Spring",
-      "content": "## Movements\n1. Very slowly\n2. Fast\n3. Moderate\n4. Quite fast\n5. Still faster\n6. Very slowly (as at first)\n7. Calm and flowing\n8. Moderate. Coda\n9. Moderate - Like a prayer",
+      "content": "",
       "frontmatter": {
         "composer": "Copland, Aaron",
         "catalogue": ""
@@ -1722,6 +1722,19 @@
       "bucketList": false
     },
     {
+      "slug": "leoncavallo-pagliacci",
+      "type": "work",
+      "path": "Works/Leoncavallo - Pagliacci.md",
+      "title": "Leoncavallo - Pagliacci",
+      "content": "",
+      "frontmatter": {
+        "composer": "Leoncavallo, Ruggero",
+        "catalogue": ""
+      },
+      "concertCount": 1,
+      "bucketList": false
+    },
+    {
       "slug": "leshnoff-double-concerto-for-clarinet-bassoon",
       "type": "work",
       "path": "Works/Leshnoff - Double Concerto for Clarinet & Bassoon.md",
@@ -2376,10 +2389,36 @@
       "bucketList": false
     },
     {
+      "slug": "puccini-la-boheme",
+      "type": "work",
+      "path": "Works/Puccini - La Boheme.md",
+      "title": "Puccini - La Boheme",
+      "content": "",
+      "frontmatter": {
+        "composer": "Puccini, Giacomo",
+        "catalogue": ""
+      },
+      "concertCount": 1,
+      "bucketList": false
+    },
+    {
       "slug": "puccini-tosca",
       "type": "work",
       "path": "Works/Puccini - Tosca.md",
       "title": "Puccini - Tosca",
+      "content": "",
+      "frontmatter": {
+        "composer": "Puccini, Giacomo",
+        "catalogue": ""
+      },
+      "concertCount": 1,
+      "bucketList": false
+    },
+    {
+      "slug": "puccini-turandot",
+      "type": "work",
+      "path": "Works/Puccini - Turandot.md",
+      "title": "Puccini - Turandot",
       "content": "",
       "frontmatter": {
         "composer": "Puccini, Giacomo",
@@ -3516,6 +3555,19 @@
       "content": "",
       "frontmatter": {
         "composer": "Vaughan Williams, Ralph",
+        "catalogue": ""
+      },
+      "concertCount": 1,
+      "bucketList": false
+    },
+    {
+      "slug": "verdi-la-forza-del-destino",
+      "type": "work",
+      "path": "Works/Verdi - La Forza del Destino.md",
+      "title": "Verdi - La Forza del Destino",
+      "content": "",
+      "frontmatter": {
+        "composer": "Verdi, Giuseppe",
         "catalogue": ""
       },
       "concertCount": 1,
@@ -10851,25 +10903,14 @@
               "type": "work",
               "path": "Works/Copland - Appalachian Spring.md",
               "title": "Copland - Appalachian Spring",
-              "content": "## Movements\n1. Very slowly\n2. Fast\n3. Moderate\n4. Quite fast\n5. Still faster\n6. Very slowly (as at first)\n7. Calm and flowing\n8. Moderate. Coda\n9. Moderate - Like a prayer",
+              "content": "",
               "frontmatter": {
                 "composer": "Copland, Aaron",
                 "catalogue": ""
               },
               "concertCount": 3,
               "bucketList": true
-            },
-            "movements": [
-              "I. Very slowly",
-              "II. Fast",
-              "III. Moderate",
-              "IV. Quite fast",
-              "V. Still faster",
-              "VI. Very slowly (as at first)",
-              "VII. Calm and flowing",
-              "VIII. Moderate. Coda",
-              "IX. Moderate - Like a prayer"
-            ]
+            }
           },
           {
             "work": {
@@ -11288,25 +11329,14 @@
               "type": "work",
               "path": "Works/Copland - Appalachian Spring.md",
               "title": "Copland - Appalachian Spring",
-              "content": "## Movements\n1. Very slowly\n2. Fast\n3. Moderate\n4. Quite fast\n5. Still faster\n6. Very slowly (as at first)\n7. Calm and flowing\n8. Moderate. Coda\n9. Moderate - Like a prayer",
+              "content": "",
               "frontmatter": {
                 "composer": "Copland, Aaron",
                 "catalogue": ""
               },
               "concertCount": 3,
               "bucketList": true
-            },
-            "movements": [
-              "I. Very slowly",
-              "II. Fast",
-              "III. Moderate",
-              "IV. Quite fast",
-              "V. Still faster",
-              "VI. Very slowly (as at first)",
-              "VII. Calm and flowing",
-              "VIII. Moderate. Coda",
-              "IX. Moderate - Like a prayer"
-            ]
+            }
           },
           {
             "work": {
@@ -11885,8 +11915,8 @@
     {
       "slug": "202302261400",
       "type": "concert",
-      "path": "Concerts/2023/202302261400 Concert - Brooklyn Symphony Orchestra.md",
-      "title": "202302261400 Concert - Brooklyn Symphony Orchestra",
+      "path": "Concerts/2023/202302261400 Concert - Brooklyn Symphony Orchestra (Wagner, Barber, Schumann).md",
+      "title": "202302261400 Concert - Brooklyn Symphony Orchestra (Wagner, Barber, Schumann)",
       "content": "",
       "frontmatter": {
         "date": "2023-02-26T14:00:00.000Z",
@@ -12054,8 +12084,8 @@
     {
       "slug": "202304161400",
       "type": "concert",
-      "path": "Concerts/2023/202304161400 Concert - Brooklyn Symphony Orchestra.md",
-      "title": "202304161400 Concert - Brooklyn Symphony Orchestra",
+      "path": "Concerts/2023/202304161400 Concert - Brooklyn Symphony Orchestra (Grieg, Sibelius).md",
+      "title": "202304161400 Concert - Brooklyn Symphony Orchestra (Grieg, Sibelius)",
       "content": "",
       "frontmatter": {
         "date": "2023-04-16T14:00:00.000Z",
@@ -13429,8 +13459,8 @@
     {
       "slug": "202410271400",
       "type": "concert",
-      "path": "Concerts/2024/202410271400 Concert - Brooklyn Symphony Orchestra (David Hagy).md",
-      "title": "202410271400 Concert - Brooklyn Symphony Orchestra (David Hagy)",
+      "path": "Concerts/2024/202410271400 Concert - Brooklyn Symphony Orchestra (Price, Beethoven, and Shostakovich).md",
+      "title": "202410271400 Concert - Brooklyn Symphony Orchestra (Price, Beethoven, and Shostakovich)",
       "content": "",
       "frontmatter": {
         "date": "2024-10-27T14:00:00.000Z",
@@ -13597,8 +13627,8 @@
     {
       "slug": "202412151400",
       "type": "concert",
-      "path": "Concerts/2024/202412151400 Concert - Brooklyn Symphony Orchestra (Andrew Kim).md",
-      "title": "202412151400 Concert - Brooklyn Symphony Orchestra (Andrew Kim)",
+      "path": "Concerts/2024/202412151400 Concert - Brooklyn Symphony Orchestra (Mendelssohn, Elgar, and Berko).md",
+      "title": "202412151400 Concert - Brooklyn Symphony Orchestra (Mendelssohn, Elgar, and Berko)",
       "content": "",
       "frontmatter": {
         "date": "2024-12-15T14:00:00.000Z",
@@ -13816,8 +13846,8 @@
     {
       "slug": "202502231400",
       "type": "concert",
-      "path": "Concerts/2025/202502231400 Concert - Brooklyn Symphony Orchestra (Nico Olarte-Hayes).md",
-      "title": "202502231400 Concert - Brooklyn Symphony Orchestra (Nico Olarte-Hayes)",
+      "path": "Concerts/2025/202502231400 Concert - Brooklyn Symphony Orchestra (Chevalier de Saint-Georges, Faure, Sankey, and Dvorak).md",
+      "title": "202502231400 Concert - Brooklyn Symphony Orchestra (Chevalier de Saint-Georges, Faure, Sankey, and Dvorak)",
       "content": "",
       "frontmatter": {
         "date": "2025-02-23T14:00:00.000Z",
@@ -13996,8 +14026,8 @@
     {
       "slug": "202504131400",
       "type": "concert",
-      "path": "Concerts/2025/202504131400 Concert - Brooklyn Symphony Orchestra (David Bernard).md",
-      "title": "202504131400 Concert - Brooklyn Symphony Orchestra (David Bernard)",
+      "path": "Concerts/2025/202504131400 Concert - Brooklyn Symphony Orchestra (Rimsky-Korsakov, Copland, and Brahms).md",
+      "title": "202504131400 Concert - Brooklyn Symphony Orchestra (Rimsky-Korsakov, Copland, and Brahms)",
       "content": "",
       "frontmatter": {
         "date": "2025-04-13T14:00:00.000Z",
@@ -14044,25 +14074,14 @@
               "type": "work",
               "path": "Works/Copland - Appalachian Spring.md",
               "title": "Copland - Appalachian Spring",
-              "content": "## Movements\n1. Very slowly\n2. Fast\n3. Moderate\n4. Quite fast\n5. Still faster\n6. Very slowly (as at first)\n7. Calm and flowing\n8. Moderate. Coda\n9. Moderate - Like a prayer",
+              "content": "",
               "frontmatter": {
                 "composer": "Copland, Aaron",
                 "catalogue": ""
               },
               "concertCount": 3,
               "bucketList": true
-            },
-            "movements": [
-              "I. Very slowly",
-              "II. Fast",
-              "III. Moderate",
-              "IV. Quite fast",
-              "V. Still faster",
-              "VI. Very slowly (as at first)",
-              "VII. Calm and flowing",
-              "VIII. Moderate. Coda",
-              "IX. Moderate - Like a prayer"
-            ]
+            }
           },
           {
             "work": {
@@ -14160,14 +14179,19 @@
     {
       "slug": "202506151400",
       "type": "concert",
-      "path": "Concerts/2025/202506151400 Concert - Brooklyn Symphony Orchestra (Felipe Tristan).md",
-      "title": "202506151400 Concert - Brooklyn Symphony Orchestra (Felipe Tristan)",
+      "path": "Concerts/2025/202506151400 Concert - Brooklyn Symphony Orchestra (Opera Selections and Tchaikovsky Symphony 4).md",
+      "title": "202506151400 Concert - Brooklyn Symphony Orchestra (Opera Selections and Tchaikovsky Symphony 4)",
       "content": "",
       "frontmatter": {
         "date": "2025-06-15T14:00:00.000Z",
         "group": "Brooklyn Symphony Orchestra",
         "works": [
           "Verdi - Overture to La Forza del Destino",
+          "Verdi - La Forza del Destino",
+          "Leoncavallo - Pagliacci",
+          "Puccini - La Boheme",
+          "Leoncavallo - Pagliacci",
+          "Puccini - Turandot",
           "Tchaikovsky - Symphony No. 4 in F Minor"
         ],
         "conductor": [
@@ -14193,6 +14217,112 @@
               "concertCount": 1,
               "bucketList": false
             }
+          },
+          {
+            "work": {
+              "slug": "verdi-la-forza-del-destino",
+              "type": "work",
+              "path": "Works/Verdi - La Forza del Destino.md",
+              "title": "Verdi - La Forza del Destino",
+              "content": "",
+              "frontmatter": {
+                "composer": "Verdi, Giuseppe",
+                "catalogue": ""
+              },
+              "concertCount": 1,
+              "bucketList": false
+            },
+            "movements": [
+              "<em>“Pace pace, mio Dio”</em>"
+            ],
+            "soloists": [
+              "Maria Brea, soprano"
+            ]
+          },
+          {
+            "work": {
+              "slug": "leoncavallo-pagliacci",
+              "type": "work",
+              "path": "Works/Leoncavallo - Pagliacci.md",
+              "title": "Leoncavallo - Pagliacci",
+              "content": "",
+              "frontmatter": {
+                "composer": "Leoncavallo, Ruggero",
+                "catalogue": ""
+              },
+              "concertCount": 1,
+              "bucketList": false
+            },
+            "movements": [
+              "<em>\"Recitar!... Vesti la giubba\"</em>"
+            ],
+            "soloists": [
+              "Dane Suarez, tenor"
+            ]
+          },
+          {
+            "work": {
+              "slug": "puccini-la-boheme",
+              "type": "work",
+              "path": "Works/Puccini - La Boheme.md",
+              "title": "Puccini - La Boheme",
+              "content": "",
+              "frontmatter": {
+                "composer": "Puccini, Giacomo",
+                "catalogue": ""
+              },
+              "concertCount": 1,
+              "bucketList": false
+            },
+            "movements": [
+              "Duet: <em>\"O soave fanciulla\"</em>"
+            ],
+            "soloists": [
+              "Maria Brea, soprano",
+              "Dane Suarez, tenor"
+            ]
+          },
+          {
+            "work": {
+              "slug": "leoncavallo-pagliacci",
+              "type": "work",
+              "path": "Works/Leoncavallo - Pagliacci.md",
+              "title": "Leoncavallo - Pagliacci",
+              "content": "",
+              "frontmatter": {
+                "composer": "Leoncavallo, Ruggero",
+                "catalogue": ""
+              },
+              "concertCount": 1,
+              "bucketList": false
+            },
+            "movements": [
+              "<em>\"Qual fiamma avea nel guardo!\"</em>"
+            ],
+            "soloists": [
+              "Maria Brea, soprano"
+            ]
+          },
+          {
+            "work": {
+              "slug": "puccini-turandot",
+              "type": "work",
+              "path": "Works/Puccini - Turandot.md",
+              "title": "Puccini - Turandot",
+              "content": "",
+              "frontmatter": {
+                "composer": "Puccini, Giacomo",
+                "catalogue": ""
+              },
+              "concertCount": 1,
+              "bucketList": false
+            },
+            "movements": [
+              "<em>\"Nessun dorma\"</em>"
+            ],
+            "soloists": [
+              "Dane Suarez, tenor"
+            ]
           },
           {
             "work": {
@@ -14824,6 +14954,15 @@
       "concertCount": 1
     },
     {
+      "slug": "leoncavallo-ruggero",
+      "type": "composer",
+      "path": "Composers/Leoncavallo, Ruggero.md",
+      "title": "Leoncavallo, Ruggero",
+      "content": "## Works\n```dataview\nLIST FROM \"Works\" WHERE contains(file.frontmatter.composer, this.file.name)\n```",
+      "frontmatter": {},
+      "concertCount": 1
+    },
+    {
       "slug": "leshnoff-jonathan",
       "type": "composer",
       "path": "Composers/Leshnoff, Jonathan.md",
@@ -15028,7 +15167,7 @@
       "title": "Puccini, Giacomo",
       "content": "## Works\n```dataview\nLIST FROM \"Works\" WHERE contains(file.frontmatter.composer, this.file.name)\n```",
       "frontmatter": {},
-      "concertCount": 2
+      "concertCount": 3
     },
     {
       "slug": "rachmaninoff-sergei",
@@ -17047,6 +17186,10 @@
         "haydn-cello-concerto-no-1",
         "beethoven-symphony-no-7-in-a-major",
         "verdi-overture-to-la-forza-del-destino",
+        "verdi-la-forza-del-destino",
+        "leoncavallo-pagliacci",
+        "puccini-la-boheme",
+        "puccini-turandot",
         "tchaikovsky-symphony-no-4-in-f-minor"
       ]
     }

--- a/next-js/app/music/seasons/[slug]/page.tsx
+++ b/next-js/app/music/seasons/[slug]/page.tsx
@@ -91,7 +91,7 @@ export default async function SeasonPage(props: PageProps) {
                   work.frontmatter.composer &&
                     `by ${formatComposerName(work.frontmatter.composer)}`,
                 ].filter(Boolean)}
-                badges={[
+                titleBadges={[
                   work.bucketList ? (
                     <BucketList played={work.concertCount > 0} />
                   ) : null,

--- a/next-js/app/music/seasons/[slug]/page.tsx
+++ b/next-js/app/music/seasons/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
 import { ListItem } from "../../components/ListItem";
 import { PageTitle } from "@music/components/PageTitle";
 import { SectionHeading } from "@music/components/SectionHeading";
+import { EmptyState } from "@/app/components/EmptyState";
 import { getSeasonBySlug } from "@music/data/queries/seasons";
 import { getConcertsBySeason } from "@music/data/queries/concerts";
 import { getWorksBySeason } from "@music/data/queries/works";
@@ -61,20 +62,25 @@ export default async function SeasonPage(props: PageProps) {
         </div>
       </div>
 
-      {concerts.length > 0 && (
-        <section>
-          <SectionHeading>Concerts</SectionHeading>
+      <section>
+        <SectionHeading>Concerts</SectionHeading>
+        {concerts.length > 0 ? (
           <div className="grid gap-4">
             {concerts.map((concert) => (
               <ConcertListItem key={concert.slug} concert={concert} />
             ))}
           </div>
-        </section>
-      )}
+        ) : (
+          <EmptyState
+            title="No concerts yet"
+            description={`I haven't performed any concerts in ${season.title} yet.`}
+          />
+        )}
+      </section>
 
-      {works.length > 0 && (
-        <section>
-          <SectionHeading>Works</SectionHeading>
+      <section>
+        <SectionHeading>Works</SectionHeading>
+        {works.length > 0 ? (
           <div className="grid gap-4">
             {works.map((work) => (
               <ListItem
@@ -93,8 +99,13 @@ export default async function SeasonPage(props: PageProps) {
               />
             ))}
           </div>
-        </section>
-      )}
+        ) : (
+          <EmptyState
+            title="No works yet"
+            description={`I haven't performed any works in ${season.title} yet.`}
+          />
+        )}
+      </section>
     </article>
   );
 }

--- a/next-js/app/music/upcoming/page.tsx
+++ b/next-js/app/music/upcoming/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { getUpcomingConcerts } from "@music/data/queries/concerts";
 import { ConcertListItem } from "@music/components/ConcertListItem";
+import { ConcertInfo } from "@music/components/ConcertInfo";
 import { getSiteUrl, isHappeningNow } from "@music/lib/helpers";
 import { SectionHeading } from "../components/SectionHeading";
 import { CalendarUrlCopy } from "../components/CalendarUrlCopy";
@@ -34,7 +35,7 @@ export default async function UpcomingPage() {
           <section className="space-y-4">
             <PageTitle>Up Next</PageTitle>
             <div className="grid gap-4 p-4 bg-surface border border-border dark:bg-surface-dark dark:border-border-dark rounded-lg">
-              <ConcertListItem concert={upNext} expanded showAttendActions />
+              <ConcertInfo concert={upNext} showAttendActions />
             </div>
           </section>
         )}

--- a/next-js/app/music/works/[slug]/page.tsx
+++ b/next-js/app/music/works/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { routes } from "@music/lib/routes";
 import { ConcertListItem } from "@music/components/ConcertListItem";
 import { PageTitle } from "@music/components/PageTitle";
 import { SectionHeading } from "@music/components/SectionHeading";
+import { EmptyState } from "@/app/components/EmptyState";
 import {
   getDateForSorting,
   formatWorkTitle,
@@ -67,16 +68,31 @@ export default async function WorkPage(props: PageProps) {
         )}
       </div>
 
-      {concerts.length > 0 && (
-        <div>
-          <SectionHeading>Concerts</SectionHeading>
+      <div>
+        <SectionHeading>Concerts</SectionHeading>
+        {concerts.length > 0 ? (
           <div className="grid gap-4">
             {concerts.map((concert) => (
               <ConcertListItem key={concert.slug} concert={concert} />
             ))}
           </div>
-        </div>
-      )}
+        ) : (
+          <EmptyState
+            title="No concerts yet"
+            description={
+              work.bucketList ? (
+                <span>
+                  This work is on the{" "}
+                  <Link href={routes.bucketList()}>Bucket List</Link>, but I
+                  haven&apos;t performed it yet.
+                </span>
+              ) : (
+                "I haven't performed this work yet."
+              )
+            }
+          />
+        )}
+      </div>
     </article>
   );
 }

--- a/next-js/app/music/works/page.tsx
+++ b/next-js/app/music/works/page.tsx
@@ -13,11 +13,9 @@ export const metadata: Metadata = {
   description: "Musical works I've performed",
 };
 
-export default async function WorksPage(
-  props: {
-    searchParams: Promise<{ [key: string]: string | undefined }>;
-  }
-) {
+export default async function WorksPage(props: {
+  searchParams: Promise<{ [key: string]: string | undefined }>;
+}) {
   const searchParams = await props.searchParams;
   let works = getWorks();
 
@@ -64,7 +62,7 @@ export default async function WorksPage(
         composer: work.frontmatter.composer,
         concerts: work.concertCount,
       },
-      badges: [
+      titleBadges: [
         work.bucketList ? <BucketList played={work.concertCount > 0} /> : null,
       ],
     };


### PR DESCRIPTION
**Add basic Empty states**
  - Work, Season, Composer all get better empty state when I haven't performed anything with them yet
<img width="33%" alt="Screenshot 2025-02-22 at 12 50 23 PM No concerts on work" src="https://github.com/user-attachments/assets/87a2a4a2-6af1-48ab-a963-d98e7405669d" />
<img width="33%" alt="Screenshot 2025-02-22 at 12 50 31 PM No works on composer" src="https://github.com/user-attachments/assets/ce403a6b-d448-43e4-bc1d-2da3b609937f" />
<img width="33%" alt="Screenshot 2025-02-22 at 12 54 14 PM No concerts or works on season" src="https://github.com/user-attachments/assets/caab1833-96ff-4673-a52a-7d55a9f1bec2" />

**Fix catalogue number**
- I had two Op. 72b's for Beethoven

**Add new `ConcertInfo` component; rework List Items**
- ConcertListItem is now just a shortcut to ListItem with smarter defaults
- ListItem now supports badges on either row:
  - `titleBadges` (for things like BucketList badge; relates to Work name, not composer)
  - `statsBadges` (for things like Upcoming badge; relates to date moreso)
  - Don't show the stats element if it's empty (was a problem showing Works on a Composer detail page)
- Update usages of ListItem to have badges in proper slots
- Update AWDS page with all the documentation changes

**Update vault data for upcoming BSO concerts**
- New works etc
- Appalachian Spring doesn't need to list movements
